### PR TITLE
docs: Shorten paths from sample-oracle-modernization-accelerator to oma

### DIFF
--- a/docs/3-1.sqlUnitTest.md
+++ b/docs/3-1.sqlUnitTest.md
@@ -627,7 +627,7 @@ Oracle 딕셔너리 추출 시작
 
 💾 딕셔너리 파일 생성 중...
   - 파일 크기: 12.5MB
-  - 저장 위치: /home/ec2-user/workspace/sample-oracle-modernization-accelerator/your-application/test/dictionary/all_dictionary.json
+  - 저장 위치: /home/ec2-user/workspace/oma/your-application/test/dictionary/all_dictionary.json
 
 ✅ 딕셔너리 추출 완료 (소요시간: 15분 20초)
 ============================================================
@@ -644,22 +644,22 @@ SQL 파일의 바인드 변수를 분석하고 데이터베이스 딕셔너리�
 ##### 📥 입력 소스
 
 - **SQL 파일들:** `${TEST_FOLDER}/src_sql_extract/`
-  - 실제 경로: `/home/ec2-user/workspace/sample-oracle-modernization-accelerator/your-application/test/src_sql_extract/`
+  - 실제 경로: `/home/ec2-user/workspace/oma/your-application/test/src_sql_extract/`
   - 파일 개수: 약 1,000-2,000개 .sql 파일
   - 파일 형식: `[매퍼네임스페이스].[SQL ID].sql`
 - **데이터베이스 딕셔너리:** `${TEST_FOLDER}/dictionary/all_dictionary.json`
-  - 실제 경로: `/home/ec2-user/workspace/sample-oracle-modernization-accelerator/your-application/test/dictionary/all_dictionary.json`
+  - 실제 경로: `/home/ec2-user/workspace/oma/your-application/test/dictionary/all_dictionary.json`
   - 파일 크기: 약 10-20MB
   - 포함 정보: 컬럼의 메타데이터 및 샘플 데이터
 
 ##### 📁 출력 디렉토리
 
 - **바인드 변수 샘플:** `${TEST_FOLDER}/sampler/`
-  - 실제 경로: `/home/ec2-user/workspace/sample-oracle-modernization-accelerator/your-application/test/sampler/`
+  - 실제 경로: `/home/ec2-user/workspace/oma/your-application/test/sampler/`
   - 파일 형식: `[매퍼네임스페이스].[SQL ID].json`
   - 생성 파일 수: SQL 파일 수와 동일
 - **로그 파일:** `${TEST_LOGS_FOLDER}/bind_sampling.log`
-  - 실제 경로: `/home/ec2-user/workspace/sample-oracle-modernization-accelerator/your-application/logs/test/bind_sampling.log`
+  - 실제 경로: `/home/ec2-user/workspace/oma/your-application/logs/test/bind_sampling.log`
 
 ##### 🔄 처리 흐름
 


### PR DESCRIPTION
- Update README.md directory structure to use 'oma' instead of long path
- Update all paths in SQL Unit Test documentation to use shortened 'oma' path
- Change /home/ec2-user/workspace/sample-oracle-modernization-accelerator to /home/ec2-user/workspace/oma
- Improve readability and reduce verbosity in documentation
- Maintain consistency across all documentation files

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
