### PR TITLE
fix: UI 오류 수정 nav_order 중복 해결

### DIFF
--- a/docs/ui-error-fix.md
+++ b/docs/ui-error-fix.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: UI 오류 수정
-nav_order: 6
+nav_order: 10
 has_children: true
 description: "UI 관련 XML 오류 수정 작업"
 ---


### PR DESCRIPTION
- docs/ui-error-fix.md: nav_order를 6에서 10으로 변경
- docs/ui-error-fix.html: 업데이트된 HTML 파일
- code-transformation.md와 nav_order: 6 중복 문제 해결

이제 Jekyll 사이드바 네비게이션에서 UI 오류 수정 섹션이 올바르게 표시됩니다.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
