### PR TITLE
fix: UI 오류 수정 섹션이 사이드바 네비게이션에 표시되도록 nav_order 조정

### DIFF
--- a/docs/ui-error-fix.md
+++ b/docs/ui-error-fix.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: UI 오류 수정
-nav_order: 9
+nav_order: 10
 has_children: true
 description: "UI 관련 XML 오류 수정 작업"
 ---

--- a/docs/ui-error-fix.md
+++ b/docs/ui-error-fix.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: UI 오류 수정
-nav_order: 6
+nav_order: 9
 has_children: true
 description: "UI 관련 XML 오류 수정 작업"
 ---

--- a/docs/useful-tools.md
+++ b/docs/useful-tools.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: 유용한 툴들
-nav_order: 9
+nav_order: 10
 description: "OMA 프로젝트에서 활용할 수 있는 유용한 도구들"
 ---
 


### PR DESCRIPTION
- docs/ui-error-fix.md: nav_order 6 → 9 (중복 해결)
- docs/useful-tools.md: nav_order 9 → 10 (순서 조정)
- 해당 HTML 파일들도 업데이트

이제 Jekyll 사이드바에서 다음 순서로 표시됩니다:
8. 결과 통합
9. UI 오류 수정 ← 새로 추가
10. 유용한 툴들

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
