### PR TITLE
Remove chalee branch from GitHub Actions workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,7 @@ name: Deploy Jekyll site to Pages
 
 on:
   push:
-    branches: ["main", "master", "chalee"]
+    branches: ["main", "master"]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
- Only build and deploy from main/master branches
- Prevent unauthorized deployment from feature branches
- chalee branch is for development only

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
